### PR TITLE
loadDocs.js: replace async.each with async.eachLimit, document rate-limiting

### DIFF
--- a/root/tasks/loadDocs.js
+++ b/root/tasks/loadDocs.js
@@ -21,14 +21,34 @@ module.exports = function(grunt) {
 
     var drive = google.drive({ auth, version: "v3" });
 
-    async.each(config.docs, async function(fileId) {
-      var meta = await drive.files.get({ fileId });
-      var name = meta.data.name.replace(/\s+/g, "_") + ".docs.txt";
-      var body = await drive.files.export({ fileId, mimeType: "text/plain" });
-      var text = body.data.replace(/\r\n/g, "\n");
-      console.log(`Writing document as data/${name}`);
-      grunt.file.write(path.join("data", name), text);
-    }, done);
+    /*
+     * Fetch the docs
+     *
+     * This is rate-limited to 2 concurrent async fetches at any given
+     * time to avoid hitting Google's rate limits. 2 is the default;
+     * you may be able to go higher. Read more about your quota at
+     * https://console.developers.google.com/apis/api/drive.googleapis.com/quotas?project=<project>
+     * where <project> is the project you authenticated with using `grunt google-auth`
+     *
+     * Rate limiting added for https://github.com/nprapps/interactive-template/issues/12
+     *
+     * Thanks to the following resources:
+     *    https://caolan.github.io/async/docs.html#eachLimit
+     *    https://stackoverflow.com/a/34865245
+     */
+    async.eachLimit(
+      config.docs,
+      2, // 2 concurrent fetches; can be higher or lower.
+      async function(fileId) {
+        var meta = await drive.files.get({ fileId });
+        var name = meta.data.name.replace(/\s+/g, "_") + ".docs.txt";
+        var body = await drive.files.export({ fileId, mimeType: "text/plain" });
+        var text = body.data.replace(/\r\n/g, "\n");
+        console.log(`Writing document as data/${name}`);
+        grunt.file.write(path.join("data", name), text);
+      },
+      done
+    );
 
   });
 }


### PR DESCRIPTION
## Changes

- Adds rate-limiting code from solution pasted in https://github.com/nprapps/interactive-template/issues/12
- Improves documentation for why and how the rate-limiting works

## Questions

- [ ] Should this be extended to loadSheets.js?