### PR TITLE
add commonly used style task

### DIFF
--- a/root/tasks/build.js
+++ b/root/tasks/build.js
@@ -33,6 +33,16 @@ module.exports = function(grunt) {
   //expose this for other tasks to use
   grunt.template.process = process;
 
+  grunt.template.style = function(hash) {
+    var styles = [];
+    for (var k in hash) {
+      if (hash[k]) {
+        styles.push([k, hash[k]].join(": "));
+      }
+    }
+    return styles.join("; ");
+  };
+
   grunt.template.formatNumber = function(s) {
     s = s + "";
     var start = s.indexOf(".");

--- a/root/tasks/build.js
+++ b/root/tasks/build.js
@@ -33,6 +33,7 @@ module.exports = function(grunt) {
   //expose this for other tasks to use
   grunt.template.process = process;
 
+  // accepts an object of css key pairs and concatenates them inline
   grunt.template.style = function(hash) {
     var styles = [];
     for (var k in hash) {


### PR DESCRIPTION
This task is used in most of our recent projects and is hard to remember to add to the created repos after adding the t.style() functions elsewhere due to copy and pasting code over from other projects. 

It's a useful function that concatenates styles inline in the EJS. I recommend we include it by default so that we don't get confused each project. 